### PR TITLE
Minimal NINJS payload for the Borsen Publisher use case

### DIFF
--- a/server/borsen/publish/__init__.py
+++ b/server/borsen/publish/__init__.py
@@ -1,0 +1,1 @@
+from . import borsen_ninjs  # noqa

--- a/server/borsen/publish/borsen_ninjs.py
+++ b/server/borsen/publish/borsen_ninjs.py
@@ -1,0 +1,49 @@
+from superdesk.publish.formatters.ninjs_formatter import NINJSFormatter
+
+
+class BorsenNINJSFormatter(NINJSFormatter):
+    """Borsen NINJS formatter
+
+    Minimal NINJS output for Børsen.
+    Output is a trimmed subset of the base NINJS output.
+    """
+
+    name = "Borsen NINJS"
+    type = "borsen_ninjs"
+
+    def __init__(self):
+        super().__init__()
+        self.format_type = self.type
+
+    def _transform_to_ninjs(self, article, subscriber, recursive=True):
+        base_ninjs = super()._transform_to_ninjs(article, subscriber, recursive=recursive)
+
+        wanted_keys = [
+            "guid",
+            "version",
+            "type",
+            "versioncreated",
+            "language",
+            "headline",
+            "urgency",
+            "pubstatus",
+            "firstcreated",
+            "firstpublished",
+            "source",
+            "priority",
+            "service",
+            "evolvedfrom",
+        ]
+
+        def _is_empty(value):
+            return value is None or value == "" or value == [] or value == {}
+
+        ninjs = {}
+        for key in wanted_keys:
+            if key not in base_ninjs:
+                continue
+            if _is_empty(base_ninjs.get(key)):
+                continue
+            ninjs[key] = base_ninjs[key]
+
+        return ninjs

--- a/server/borsen/publish/borsen_ninjs.py
+++ b/server/borsen/publish/borsen_ninjs.py
@@ -4,7 +4,7 @@ from superdesk.publish.formatters.ninjs_formatter import NINJSFormatter
 class BorsenNINJSFormatter(NINJSFormatter):
     """Borsen NINJS formatter
 
-    Minimal NINJS output for Børsen.
+    Minimal NINJS output required by Børsen.
     Output is a trimmed subset of the base NINJS output.
     """
 
@@ -16,6 +16,7 @@ class BorsenNINJSFormatter(NINJSFormatter):
         self.format_type = self.type
 
     def _transform_to_ninjs(self, article, subscriber, recursive=True):
+        """Return a trimmed-down NINJS dict with just the fields Børsen needs."""
         base_ninjs = super()._transform_to_ninjs(article, subscriber, recursive=recursive)
 
         wanted_keys = [
@@ -40,10 +41,7 @@ class BorsenNINJSFormatter(NINJSFormatter):
 
         ninjs = {}
         for key in wanted_keys:
-            if key not in base_ninjs:
-                continue
-            if _is_empty(base_ninjs.get(key)):
-                continue
-            ninjs[key] = base_ninjs[key]
+            if base_ninjs.get(key):
+                ninjs[key] = base_ninjs[key]
 
         return ninjs

--- a/server/borsen/publish/borsen_ninjs.py
+++ b/server/borsen/publish/borsen_ninjs.py
@@ -19,7 +19,7 @@ class BorsenNINJSFormatter(NINJSFormatter):
         """Return a trimmed-down NINJS dict with just the fields Børsen needs."""
         base_ninjs = super()._transform_to_ninjs(article, subscriber, recursive=recursive)
 
-        wanted_keys = [
+        wanted_fields = {
             "guid",
             "version",
             "type",
@@ -34,14 +34,6 @@ class BorsenNINJSFormatter(NINJSFormatter):
             "priority",
             "service",
             "evolvedfrom",
-        ]
+        }
 
-        def _is_empty(value):
-            return value is None or value == "" or value == [] or value == {}
-
-        ninjs = {}
-        for key in wanted_keys:
-            if base_ninjs.get(key):
-                ninjs[key] = base_ninjs[key]
-
-        return ninjs
+        return {field: base_ninjs[field] for field in wanted_fields if base_ninjs.get(field)}

--- a/server/settings.py
+++ b/server/settings.py
@@ -23,6 +23,7 @@ INSTALLED_APPS = [
     "planning",
     "superdesk.auth.saml",
     "borsen.io",
+    "borsen.publish",
 ]
 
 PLANNING_EVENT_TEMPLATES_ENABLED = True

--- a/server/tests/publish/borsen_ninjs_test.py
+++ b/server/tests/publish/borsen_ninjs_test.py
@@ -31,6 +31,7 @@ class BorsenNinjsFormatterTest(TestCase):
         article = {
             ITEM_TYPE: CONTENT_TYPE.TEXT,
             "guid": EXPECTED_NINJS["guid"],
+            # NINJSFormatter reads version from eve's VERSION field (usually "_version")
             config.VERSION: int(EXPECTED_NINJS["version"]),
             "versioncreated": EXPECTED_NINJS["versioncreated"],
             "language": EXPECTED_NINJS["language"],
@@ -41,13 +42,18 @@ class BorsenNinjsFormatterTest(TestCase):
             "firstpublished": EXPECTED_NINJS["firstpublished"],
             "source": EXPECTED_NINJS["source"],
             "priority": EXPECTED_NINJS["priority"],
-            # service is populated from anpa_category
+            # service is populated from anpa_category via _get_service/format_cv_item
             "anpa_category": [
                 {
                     "qcode": EXPECTED_NINJS["service"][0]["code"],
                     "name": EXPECTED_NINJS["service"][0]["name"],
                 }
             ],
+            # Extra fields that must not be in the Børsen-trimmed NINJS output.
+            "ingest_provider": "test",
+            "slugline": "test",
+            "byline": "test",
+            "body_html": "<p>test</p>",
         }
 
         # Base NINJS sets "evolvedfrom" from "rewrite_of". Only set it if fixture has it.

--- a/server/tests/publish/borsen_ninjs_test.py
+++ b/server/tests/publish/borsen_ninjs_test.py
@@ -1,0 +1,68 @@
+import pathlib
+
+from flask import json
+from unittest import mock
+
+from eve.utils import config
+from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE
+from superdesk.tests import TestCase
+
+from borsen.publish.borsen_ninjs import BorsenNINJSFormatter
+
+
+FIXTURE_PATH = pathlib.Path(__file__).parent.joinpath("fixtures", "borsen-ninjs.json")
+with open(FIXTURE_PATH) as f:
+    EXPECTED_NINJS = json.load(f)
+
+
+@mock.patch(
+    "superdesk.publish.subscribers.SubscribersService.generate_sequence_number",
+    lambda self, subscriber: 1,
+)
+class BorsenNinjsFormatterTest(TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        super().setUp()
+        self.formatter = BorsenNINJSFormatter()
+
+    def _build_article(self, overrides=None):
+        """Build a minimal article that will produce the expected Børsen NINJS."""
+        article = {
+            ITEM_TYPE: CONTENT_TYPE.TEXT,
+            "guid": EXPECTED_NINJS["guid"],
+            config.VERSION: int(EXPECTED_NINJS["version"]),
+            "versioncreated": EXPECTED_NINJS["versioncreated"],
+            "language": EXPECTED_NINJS["language"],
+            "headline": EXPECTED_NINJS["headline"],
+            "urgency": EXPECTED_NINJS["urgency"],
+            "pubstatus": EXPECTED_NINJS["pubstatus"],
+            "firstcreated": EXPECTED_NINJS["firstcreated"],
+            "firstpublished": EXPECTED_NINJS["firstpublished"],
+            "source": EXPECTED_NINJS["source"],
+            "priority": EXPECTED_NINJS["priority"],
+            # service is populated from anpa_category
+            "anpa_category": [
+                {
+                    "qcode": EXPECTED_NINJS["service"][0]["code"],
+                    "name": EXPECTED_NINJS["service"][0]["name"],
+                }
+            ],
+        }
+
+        # Base NINJS sets "evolvedfrom" from "rewrite_of". Only set it if fixture has it.
+        if EXPECTED_NINJS.get("evolvedfrom"):
+            article["rewrite_of"] = EXPECTED_NINJS["evolvedfrom"]
+
+        if overrides:
+            article.update(overrides)
+        return article
+
+    def _format(self, overrides=None):
+        article = self._build_article(overrides)
+        _, doc = self.formatter.format(article, {"name": "Test Subscriber"})[0]
+        return json.loads(doc)
+
+    def test_borsen_ninjs_matches_fixture(self):
+        ninjs = self._format()
+        self.assertEqual(ninjs, EXPECTED_NINJS)

--- a/server/tests/publish/fixtures/borsen-ninjs.json
+++ b/server/tests/publish/fixtures/borsen-ninjs.json
@@ -1,0 +1,20 @@
+{
+  "guid": "3830be9b-18d2-44f6-9e63-51fbf3a6557e",
+  "version": "1",
+  "type": "text",
+  "versioncreated": "2026-03-03T18:43:44+0000",
+  "language": "en",
+  "headline": "Test title",
+  "urgency": 3,
+  "pubstatus": "usable",
+  "firstcreated": "2026-03-03T18:43:13+0000",
+  "firstpublished": "2026-03-03T18:43:44+0000",
+  "source": "SF",
+  "priority": 1,
+  "service": [
+    {
+      "code": "category1",
+      "name": "Category 1"
+    }
+  ]
+}


### PR DESCRIPTION
As articles in the Borsen's Publisher database are being used for content lists only, sending the complete payload to the Publisher is not required. Sending the minimal payload will make the operations more efficient, specifically regarding media rich articles which Borsen often produces, as images are not part of the payload, hence not being processed and copied to the Publisher S3 bucket. This format will also be used for the Borsen Amazon SQS destination, removing the payload size constraints. 